### PR TITLE
(SIMP-303) Removed pry-debugger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ end
 
 group :development do
   gem 'pry'
-  gem 'pry-debugger'
   gem 'rb-readline'
   gem 'awesome_print'
 end


### PR DESCRIPTION
Pry-debugger does not work with Ruby > 2.

SIMP-303 #close #comment Compat with Ruby>2
